### PR TITLE
feat: raise HPA max from 1 to 4 to match live cluster state

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -67,7 +67,7 @@ jobs:
           Version: ${{ github.sha }}
           Env: prod
           Replicas.Min: 1
-          Replicas.Max: 1
+          Replicas.Max: 4
           Image: ${{ env.REGISTRY }}/${{ steps.repository_string.outputs.lowercase }}:${{ github.sha }}
           Requests.Memory: 192Mi
           Requests.CPU: 150m


### PR DESCRIPTION
The `k8s/manifest.yml` already defines a HorizontalPodAutoscaler block parameterised by `#{Replicas.Min}#` and `#{Replicas.Max}#`, but the `build-and-release.yml` workflow was substituting `Replicas.Max: 1`, which effectively neutered the HPA — capping it at one replica regardless of load. The live cluster currently runs plugins-api with HPA `min=1, max=4`, so each deploy was applying a manifest that contradicted the running configuration (manifest drift). This change brings the workflow's substitution in line with what's actually running in prod: `Replicas.Min: 1` stays, and `Replicas.Max` becomes `4`. No manifest change is required.